### PR TITLE
Added permission node

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -2,3 +2,7 @@ name: BLScriptEnable
 main: BLScriptEnable
 version: 1.0
 api: 1.5
+permissions:
+  blscriptenable.usescripts:
+    default: true
+    description: Allow usage of BlockLauncher scripts

--- a/src/BLScriptEnable.php
+++ b/src/BLScriptEnable.php
@@ -16,10 +16,12 @@ class BLScriptEnable extends PluginBase implements Listener {
 	 * @priority MONITOR
 	 */
 	public function onPlayerJoin(PlayerJoinEvent $event){
-		$pk = new TextPacket();
-		$pk->type = TextPacket::TYPE_CHAT;
-		$pk->source = "";
-		$pk->message = TextFormat::BLACK . "BlockLauncher, enable scripts";
-		$event->getPlayer()->dataPacket($pk->setChannel(Network::CHANNEL_TEXT));
+        if($event->getPlayer()->hasPermission("blscriptenable.usescripts")) {
+            $pk = new TextPacket();
+            $pk->type = TextPacket::TYPE_CHAT;
+            $pk->source = "";
+            $pk->message = TextFormat::BLACK . "BlockLauncher, enable scripts";
+            $event->getPlayer()->dataPacket($pk->setChannel(Network::CHANNEL_TEXT));
+        }
 	}
 }


### PR DESCRIPTION
This PR adds a permission node, so that the server admin can choose which players get to use BlockLauncher scripts. The current behaviour is preserved, in that all players can use scripts by default.
